### PR TITLE
Initial commit

### DIFF
--- a/JetPack-4.2.3.init.patch
+++ b/JetPack-4.2.3.init.patch
@@ -1,0 +1,20 @@
+--- init	2019-11-06 05:48:06.000000000 +0800
++++ abc/init_new	2020-12-24 11:59:58.000000000 +0800
+@@ -59,7 +59,7 @@
+ 
+ echo "L4T-INITRD Build DATE: $build_date" > /dev/kmsg;
+ 
+-rootdev="$(sed -ne 's/.*\broot=\/dev\/\([abcdefklmnps0-9]*\)\b.*/\1/p' < /proc/cmdline)"
++rootdev="$(sed -ne 's/.*\broot=\/dev\/\([abcdefklmnpsv0-9]*\)\b.*/\1/p' < /proc/cmdline)"
+ if [ "${rootdev}" == "" ]; then
+ 	uuid_regex='[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}'
+ 	rootdev="$(sed -ne "s/.*\broot=\(PARTUUID=${uuid_regex}\)\b.*/\1/p" < /proc/cmdline)"
+@@ -85,7 +85,7 @@
+ 		echo "ERROR: ${rootdev} mount fail..." > /dev/kmsg;
+ 		exec /bin/bash;
+ 	fi;
+-elif [[ "${rootdev}" == mmcblk* ]]; then
++elif [[ "${rootdev}" == mmcblk* ]] || [[ "${rootdev}" == nvme0n* ]]; then
+ 	if [ ! -e "/dev/${rootdev}" ]; then
+ 		count=0;
+ 		while [ ${count} -lt 50 ]

--- a/JetPack-4.2.menu.txt
+++ b/JetPack-4.2.menu.txt
@@ -1,0 +1,7 @@
+
+LABEL <JETPACK_LABEL>
+      MENU LABEL JetPack 4.2 <JETPACK_LABEL>
+      LINUX /boot/jp-4.2.Image
+      INITRD /boot/jp-4.2.initrd
+      FDT /boot/tegra194-p2888-0001-p2822-0000.jp-42.dtb
+      APPEND ${cbootargs} quiet root=<ROOTDEV> rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4

--- a/JetPack-4.3.init.patch
+++ b/JetPack-4.3.init.patch
@@ -1,0 +1,21 @@
+--- init	2019-12-10 15:02:52.000000000 +0800
++++ init_new	2020-12-17 14:57:22.000000000 +0800
+@@ -59,7 +59,8 @@
+ 	chmod 755 /sbin/reboot;
+ fi;
+ 
+-rootdev="$(sed -ne 's/.*\broot=\/dev\/\([abcdefklmnps0-9]*\)\b.*/\1/p' < /proc/cmdline)"
++
++rootdev="$(sed -ne 's/.*\broot=\/dev\/\([abcdefklmnpsv0-9]*\)\b.*/\1/p' < /proc/cmdline)"
+ if [ "${rootdev}" == "" ]; then
+ 	uuid_regex='[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}'
+ 	rootdev="$(sed -ne "s/.*\broot=\(PARTUUID=${uuid_regex}\)\b.*/\1/p" < /proc/cmdline)"
+@@ -85,7 +86,7 @@
+ 		echo "ERROR: ${rootdev} mount fail..." > /dev/kmsg;
+ 		exec /bin/bash;
+ 	fi;
+-elif [[ "${rootdev}" == mmcblk* ]]; then
++elif [[ "${rootdev}" == mmcblk* ]] || [[ "${rootdev}" == nvme0* ]]; then
+ 	if [ ! -e "/dev/${rootdev}" ]; then
+ 		count=0;
+ 		while [ ${count} -lt 50 ]

--- a/JetPack-4.4.1.init.patch
+++ b/JetPack-4.4.1.init.patch
@@ -1,0 +1,23 @@
+--- _44/init	2020-10-17 03:36:55.000000000 +0800
++++ _out/init	2021-03-05 15:24:26.874349434 +0800
+@@ -59,9 +59,10 @@
+ 	chmod 755 /sbin/reboot;
+ fi;
+ 
+-dev_regex='root=\/dev\/[abcdefklmnps0-9]*'
++dev_regex='root=\/dev\/[abcdefklmnpsv0-9]*'
+ uuid_regex='root=PARTUUID=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+ rootdev="$(cat /proc/cmdline | grep -oE "\<${dev_regex}|${uuid_regex}\>" | tail -1)"
++
+ if [ "${rootdev}" != "" ]; then
+ 	if [[ "${rootdev}" =~ "PARTUUID" ]]; then
+ 		rootdev=$(echo "${rootdev}" | sed -ne "s/root=\(.*\)/\1/p")
+@@ -87,7 +88,7 @@
+ 		echo "ERROR: ${rootdev} mount fail..." > /dev/kmsg;
+ 		exec /bin/bash;
+ 	fi;
+-elif [[ "${rootdev}" == mmcblk* ]]; then
++elif [[ "${rootdev}" == mmcblk* ]] || [[ "${rootdev}" == nvme0* ]]; then
+ 	if [ ! -e "/dev/${rootdev}" ]; then
+ 		count=0;
+ 		while [ ${count} -lt 50 ]

--- a/JetPack-4.x.menu.txt
+++ b/JetPack-4.x.menu.txt
@@ -1,0 +1,6 @@
+
+LABEL <JETPACK_LABEL>
+      MENU LABEL JetPack <VERSION> <JETPACK_LABEL>
+      LINUX /boot/jp-<VERSION>.Image
+      INITRD /boot/jp-<VERSION>.initrd
+      APPEND ${cbootargs} quiet root=<ROOTDEV> rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,158 @@
+# Multi-booting for the Jetson AGX Xavier with NVMe SSD
+[![](https://badgen.net/badge/platform/jetson-xavier)](https://developer.nvidia.com/embedded/jetson-agx-xavier-developer-kit)
+
+This project provides tools to add boot entry to `extlinux.conf` for a partition with JetPack installed.  This allows multi-booting via the [serial console](https://elinux.org/Jetson/AGX_Xavier_Tegra_Combined_UART).
+
+# Overview
+## Why NVMe SSD
+* SSD provides much faster IO speed
+```
+/dev/mmcblk0p1 (internal EMMC): Bufferd reads = 292 MB/s
+/dev/mmcblk1p1 (Sandisk Ultra U1 SD card): Bufferd reads = 81 MB/s
+/dev/nvme0n1p1 (Kingston NVME M.2): Bufferd reads = 1316 MB/s
+/dev/nvme0n1p1 (970 EVO Plus M.2): Bufferd reads = 1670 MB/s
+```
+* SSD has larger storage capacity (>1TB) than eMMC (32GB)
+* There is no way to upgrade/replace eMMC (although NVIDIA claims it can last up to [5 years](https://developer.nvidia.com/embedded/faq#jetson-lifetime))
+
+## Why Multi-booting
+* Try different JetPack versions without changing SSD or reflash.  (For example, `jetpack_44` on `/dev/nvme0n1p1`, `jetpack-4.3` on `/dev/nvme0n1p2`)
+* Run different projects with same JetPack version without changing SSD or reflash (Say, `jp44_human_pose` on `/dev/nvme0n1p1`, `jp44_jetbot` on `/dev/nvme0n1p2`)
+* Replace a SSD without reflash (Maybe `john_jetpack_44` on `/dev/nvme0n1p1`, `jane_jetpack_45` on `/dev/nvme0n1p1`)
+* Just for fun
+
+## What JetPack Versions are Supported:
+The project has been tested with the following JetPack versions:
+* JetPack 4.5.1
+* JetPack 4.4.1
+* JetPack 4.3
+* JetPack 4.2.3
+
+<br />
+
+# Preparation
+This section will help you to prepare the bootable partition(s) with desired JetPack version.  We assume that you know how to format disk with GPT partitioning scheme and create/delete partition(s) using [GNOME Disk Utility](#reference)
+
+## How to Flash
+### Method 1: Use [SDK Manager GUI](https://developer.nvidia.com/nvidia-sdk-manager)
+1. Connect Jetson Xavier (in [Recovery Mode](#force-recovery-mode-when-power-off)) to the host with SDK Manager installed
+2. Select target operating system (JetPack version)
+3. Complete the Ubuntu system configuration
+
+### Method 2: Use *flash.s<span>h</span>*
+This method is more precise but only available when Jetson OS image has been created before (The path varies from version to version.  By default it should be under user's home folder).  For example, to flash `JetPack 4.4.1`:
+```bash
+$ cd ~/nvidia/nvidia_sdk/
+$ cd JetPack_4.4.1_Linux_JETSON_AGX_XAVIER/Linux_for_Tegra
+$ sudo ./flash.sh jetson-xavier mmcblk0p1
+```
+After flashing, complete the Ubuntu system configuration.
+
+## Clone *rootfs* to the target partition
+My method here is simple but not a beautiful/clean cloning.  You could find other way from Internet or use it as-is.  Now, Jetson Xavier should be booted with JetPack version installed in previous step from eMMC.  If we would like to clone *rootfs* to `/dev/nvme0n1p1`, please follow the steps below:
+```bash
+$ mkdir /tmp/rootfs
+$ sudo mount /dev/nvme0n1p1 /tmp/rootfs
+$ cd /
+$ sudo cp -ax ./ /tmp/rootfs
+```
+
+## Prepare a Backup entry on eMMC
+This allow you to boot Jetson Xavier even there is no SSD installed (or something wrong with the SSD, point to wrong partition or incorrect boot entry).  We should install the latest JetPack version (to support bootin older version).  Follows section [How to Flash](#how-to-flash) to flash `JetPack 4.5.1`
+
+After that, `JetPack 4.5.1` should be installed on eMMC and `JetPack 4.4.1` on `/dev/nvme0n1p1`.
+
+<br />
+
+# Add Boot Entry
+To continue the previous example, to enable multi-booting (`JetPack 4.5.1` on eMMC and `JetPack 4.4.1` on `/dev/nvme0n1p1`), we could run the following steps:
+```bash
+$ sudo -i
+# /path/to/multi-booting-xavier/add_jetpack.sh /dev/nvme0n1p1 human_pose
+```
+Once completed successfully and reboot, you could find something like the following via the serial console:
+```
+[0005.815] I> L4T boot options
+[0005.815] I> [1]: "primary kernel"
+[0005.815] I> [2]: "JetPack 4.4 human_pose"
+[0005.816] I> Enter choice:
+```
+At that point, you can choose the kernel before expiration of the `TIMEOUT` period (3 seconds).
+
+## A Complete Example
+Let's say the NVMe SSD has four partitions and are assigned as the following (You can check the final [multi-booting configuration](extlinux.conf.sample)):
+
+Partition       | JetPack Version | Project
+--------------- | --------------- | -----------
+/dev/nvme0n1p1  | JetPack 4.5.1   | human_pose
+/dev/nvme0n1p2  | JetPack 4.4.1   | jp44_jetbot
+/dev/nvme0n1p3  | JetPack 4.3     | DeepSpeech
+/dev/nvme0n1p4  | JetPack 4.2.3   | smart_detector
+
+To enable multi-booting with different JetPack versions like that.  Just follow the steps below:
+1. Flash `JetPack 4.2.3` to eMMC
+2. Clone *rootfs* to `/dev/nvme0n1p4`
+3. Flash `JetPack 4.3` to eMMC
+4. Clone *rootfs* to `/dev/nvme0n1p3`
+5. Flash `JetPack 4.4.1` to eMMC
+6. Clone *rootfs* to `/dev/nvme0n1p2`
+7. Flash `JetPack 4.5.1` to eMMC
+8. Clone *rootfs* to `/dev/nvme0n1p1`
+9. Run `add_jetpack.sh /dev/nvme0n1p1 human_pose`
+10. Run `add_jetpack.sh /dev/nvme0n1p2 jp44_jetbot`
+11. Run `add_jetpack.sh /dev/nvme0n1p3 DeepSpeech`
+12. Run `add_jetpack.sh /dev/nvme0n1p4 smart_detector`
+13. Done
+
+When the system boots, you could find something like the following via the serial console:
+```
+[0005.815] I> L4T boot options
+[0005.815] I> [1]: "primary kernel"
+[0005.815] I> [2]: "JetPack 4.5 human_pose"
+[0005.815] I> [2]: "JetPack 4.4 jp44_jetbot"
+[0005.815] I> [2]: "JetPack 4.3 DeepSpeech"
+[0005.816] I> [2]: "JetPack 4.2 smart_detector"
+[0005.816] I> Enter choice:
+```
+You can select the kernel everytime or you could update the default by [editing extlinux.conf](#edit-extlinux.conf)
+
+<br />
+
+# Notes
+Maybe you will find that it is not that useful as you need to flash the eMMC and clone the *rootfs* everytime for a new partition.
+
+To avoid the redundant work, it is recommended to backup the partition(s) you need.  You can use [`dd`](https://elinux.org/Jetson/AGX_Xavier_Alternative_II_For_Cloning), [`cpio`](https://forums.developer.nvidia.com/t/xavier-cloning/65159/5) or a spare storage to keep the partition(s).
+
+Next time, you can simply restore/clone the backup to the new partition, run the command `add_jetpack.sh` on Jetson Xavier and done.
+
+<br />
+
+# Miscellaneous
+## Force Recovery Mode (when Power Off)
+1. Press and hold down the Force Recovery button
+2. Press and hold down the Power button
+3. Release both buttons
+
+## Force Recovery Mode (when Power On)
+1. Press and hold down the Force Recovery button
+2. Press and hold down the Reset button
+3. Release both buttons
+
+## Edit `extlinux.conf`
+**Be Cautious**.  Invalid `extlinux.conf` will cause the system to become unbootable.  Backup before you edit, think twice before you act, double check before you save.
+
+To ensure we are editing the correct `extlinux.conf`, do the following:
+```bash
+$ mkdir /tmp/emmc
+$ sudo mount /dev/mmcblk0p1 /tmp/emmc
+$ sudo vi /tmp/emmc/boot/extlinux/extlinux.conf
+```
+
+<br />
+
+# Reference
+* [NVIDIA Jetson Xavier - CBoot](https://docs.nvidia.com/jetson/archives/l4t-archived/l4t-3231/index.html#page/Tegra%2520Linux%2520Driver%2520Package%2520Development%2520Guide%2Fbootflow_jetson_xavier.html%23wwpID0E0HB0HA)
+* [Disk Utility](https://linuxhint.com/gnome_disk_utility/)
+* [How to Boot from NVMe SSD](https://forums.developer.nvidia.com/t/how-to-boot-from-nvme-ssd/65147/17)
+* [NVIDIA Jetson Xavier - Using the serial console](https://developer.ridgerun.com/wiki/index.php?title=Xavier%2FIn_Board%2FGetting_in_Board%2FSerial_Console)
+* [Quad-RS232 Driver for Windows](https://ftdichip.com/wp-content/uploads/2021/02/CDM21228_Setup.zip)

--- a/add_jetpack.sh
+++ b/add_jetpack.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# SCRIPT: add_jetpack.sh
+# AUTHOR: Wu (https://github.com/stupid-2020)
+# DATE  : 07-MAR-2021
+# NOTE  : Only on Jetson AGX Xavier
+#
+
+DATE=`date +"%Y%m%d-%H%M%S"`
+SCRIPT_PATH=`realpath $0`
+ROOT=`dirname $SCRIPT_PATH`
+CUR_DIR=$PWD
+
+show_usage() {
+    echo "Usage: $0 jetpack_partition menu_label"
+    echo "  example:      $0 /dev/nvme0n1p1 my_jetpack_44"
+    exit
+}
+
+# Check arguments
+if [[ "$#" < 2 ]]; then
+    show_usage
+fi
+
+# Check user
+if [[ "$EUID" -ne 0 ]]; then
+    echo "This script must be run with root privileges"
+    show_usage;
+fi
+
+# Check JetPack partition
+PART_DEV=$1
+PART_MOUNT="/tmp/_nvme"
+RELEASE_FILE="$PART_MOUNT/etc/nv_tegra_release"
+VERSION="FALSE"
+if [[ -e "$1" ]]; then
+    mkdir -p $PART_MOUNT
+    mount $PART_DEV $PART_MOUNT
+    if [[ -f $RELEASE_FILE ]]; then
+       VERSION=`head -n 1 $RELEASE_FILE | cut -d',' -f2 | cut -d' ' -f3`
+    fi
+fi
+
+# Convert the JetPack version
+case $VERSION in
+    5.1)
+        VERSION="4.5"
+	;;
+    4.4)
+        VERSION="4.4"
+	;;
+    3.1)
+        VERSION="4.3"
+	;;
+    2.3)
+        VERSION="4.2"
+	;;
+    *)
+	echo "Revision: $VERSION is not supported"
+	VERSION="FALSE"
+	;;
+esac
+
+if [[ "$VERSION" == "FALSE" ]]; then
+    # Cleanup
+    umount -f -l $PART_MOUNT
+    rmdir $PART_MOUNT
+
+    echo "JetPack partition $PART_DEV not found or invalid"
+    show_usage
+fi
+
+# Everything looks ok
+# Mount
+EMMC_DEV="/dev/mmcblk0p1"
+EMMC_MOUNT="/tmp/_emmc"
+mkdir -p $EMMC_MOUNT
+mount $EMMC_DEV $EMMC_MOUNT
+
+# Patch initrd if necessary
+# - JetPack 4.5.1 fixed the regex pattern for rootdev,
+#   no patching is required
+INITRD="/boot/jp-$VERSION.initrd"
+if [[ "$VERSION" == "4.5" ]]; then
+    cp $PART_MOUNT/boot/initrd $EMMC_MOUNT/$INITRD
+else
+    $ROOT/patch_initrd.sh \
+        $PART_MOUNT/boot/initrd $VERSION $EMMC_MOUNT/$INITRD
+fi
+
+# Copy Image and Image.sig
+IMAGE="/boot/jp-$VERSION.Image"
+IMAGE_SIG="/boot/jp-$VERSION.Image.sig"
+cp $PART_MOUNT/boot/Image $EMMC_MOUNT/$IMAGE
+cp $PART_MOUNT/boot/Image.sig $EMMC_MOUNT/$IMAGE_SIG
+
+# Only for JetPack 4.2
+SRC_DTB="/boot/tegra194-p2888-0001-p2822-0000.dtb"
+DST_DTB="/boot/tegra194-p2888-0001-p2822-0000.jp-42.dtb"
+if [[ "$VERSION" == "4.2" ]]; then
+    cp $PART_MOUNT/$SRC_DTB $EMMC_MOUNT/$DST_DTB
+fi
+
+# Add entry to extlinux.conf
+JETPACK_LABEL=$2
+ROOTDEV=$PART_DEV
+EXTLINUX_CONF=$EMMC_MOUNT/boot/extlinux/extlinux.conf
+if [[ "$VERSION" == "4.2" ]]; then
+    TEMPLATE="$ROOT/JetPack-4.2.menu.txt"
+else
+    TEMPLATE="$ROOT/JetPack-4.x.menu.txt"
+fi
+while IFS= read -r line
+do
+    newline=${line/"<JETPACK_LABEL>"/$JETPACK_LABEL}
+    newline=${newline/"<ROOTDEV>"/$ROOTDEV}
+    newline=${newline/"<VERSION>"/$VERSION}
+    echo "$newline" >> $EXTLINUX_CONF
+done < "$TEMPLATE"
+
+
+# Cleanup
+umount $EMMC_MOUNT
+umount $PART_MOUNT
+rmdir $EMMC_MOUNT
+rmdir $PART_MOUNT
+
+# Show the information
+echo "rootdev: $PART_DEV"
+echo "jetpack: $VERSION"
+echo "label  : $JETPACK_LABEL"
+echo ""
+echo "Please update the default menu from extlinux.conf accordingly"
+
+# Return to original working directory
+cd $CUR_DIR

--- a/extlinux.conf.sample
+++ b/extlinux.conf.sample
@@ -1,0 +1,54 @@
+TIMEOUT 30
+DEFAULT primary
+
+MENU TITLE L4T boot options
+
+LABEL primary
+      MENU LABEL primary kernel (JetPack 4.5.1)
+      LINUX /boot/Image
+      INITRD /boot/initrd
+      APPEND ${cbootargs} quiet root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4
+
+# When testing a custom kernel, it is recommended that you create a backup of
+# the original kernel and add a new entry to this file so that the device can
+# fallback to the original kernel. To do this:
+#
+# 1, Make a backup of the original kernel
+#      sudo cp /boot/Image /boot/Image.backup
+#
+# 2, Copy your custom kernel into /boot/Image
+#
+# 3, Uncomment below menu setting lines for the original kernel
+#
+# 4, Reboot
+
+# LABEL backup
+#    MENU LABEL backup kernel
+#    LINUX /boot/Image.backup
+#    INITRD /boot/initrd
+#    APPEND ${cbootargs}
+
+LABEL human_pose
+      MENU LABEL JetPack 4.5 human_pose
+      LINUX /boot/jp-4.5.Image
+      INITRD /boot/jp-4.5.initrd
+      APPEND ${cbootargs} quiet root=/dev/nvme0n1p1 rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4
+
+LABEL jp44_jetbot
+      MENU LABEL JetPack 4.4 jp44_jetbot
+      LINUX /boot/jp-4.4.Image
+      INITRD /boot/jp-4.4.initrd
+      APPEND ${cbootargs} quiet root=/dev/nvme0n1p2 rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4
+
+LABEL DeepSpeech
+      MENU LABEL JetPack 4.3 DeepSpeech
+      LINUX /boot/jp-4.3.Image
+      INITRD /boot/jp-4.3.initrd
+      APPEND ${cbootargs} quiet root=/dev/nvme0n1p3 rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4
+
+LABEL smart_detector
+      MENU LABEL JetPack 4.2 smart_detector
+      LINUX /boot/jp-4.2.Image
+      INITRD /boot/jp-4.2.initrd
+      FDT /boot/tegra194-p2888-0001-p2822-0000.jp-42.dtb
+      APPEND ${cbootargs} quiet root=/dev/nvme0n1p4 rw rootwait rootfstype=ext4 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 net.ifnames=0 rootfstype=ext4

--- a/patch_initrd.sh
+++ b/patch_initrd.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# SCRIPT: patch_initrd.sh
+# AUTHOR: Wu (https://github.com/stupid-2020)
+# DATE  : 07-MAR-2021
+# NOTE  : Only on Jetson AGX Xavier
+#
+
+DATE=`date +"%Y%m%d-%H%M%S"`
+TMP_DIR="/tmp/_initrd.$DATE"
+SCRIPT_PATH=`realpath $0`
+ROOT=`dirname $SCRIPT_PATH`
+CUR_DIR=$PWD
+
+show_usage() {
+    echo "Usage: $0 /path/to/initrd version [output]"
+    echo "  version       should be 4.2, 4.3 or 4.4"
+    echo "  output        optional (default: /tmp/JP4X.initrd)"
+    exit
+}
+
+# Reading arguments
+if [[ "$#" < 2 ]]; then
+    show_usage
+fi
+
+INITRD=`realpath $1`
+if [[ ! -f "$INITRD" ]]; then
+    echo "Initial ramdisk file $INITRD not found."
+    show_usage;
+fi
+
+case $2 in
+    4.2)
+        PATCH="JetPack-4.2.3.init.patch"
+        ;;
+    4.3)
+        PATCH="JetPack-4.3.init.patch"
+        ;;
+    4.4)
+        PATCH="JetPack-4.4.1.init.patch"
+        ;;
+    *)
+        echo "Version $2 not supported"
+        PATCH="JetPack-unknown.init.patch"
+        ;;
+esac
+
+PATCH_FILE="$ROOT/$PATCH"
+if [[ ! -f "$PATCH_FILE" ]]; then
+    show_usage;
+fi
+
+if [[ "$3" == "" ]]; then
+    OUTPUT="/tmp/JP4X.initrd"
+else
+    OUTPUT=`realpath $3`
+fi
+
+
+# Unpack
+mkdir -p $TMP_DIR
+cd $TMP_DIR
+gzip -cd $INITRD | cpio -imd
+
+# Patch (Back up the original)
+patch -b < $PATCH_FILE
+if [[ $? -eq 0 ]]; then
+    # Pack
+    find . -print0 | cpio --null --quiet -H newc -o | gzip -9 -n > $OUTPUT
+    echo "Patch completed"
+else
+    echo "Patch failed"
+fi
+
+# Cleanup
+rm -rf $TMP_DIR
+
+# Show the information
+echo "source: $INITRD"
+echo "output: $OUTPUT"
+echo "patch : $PATCH_FILE"
+
+# Return to original working directory
+cd $CUR_DIR


### PR DESCRIPTION
- [x] Added README.md
- [x] Tested with JetPack 4.5.1, JetPack 4.4.1, JetPack 4.3 and JetPack 4.2.3
- JetPack 4.5.1 fixed the regex pattern for `rootdev` and therefore patch initrd is NOT required